### PR TITLE
Corrige erro de compilação

### DIFF
--- a/reports/.gitignore
+++ b/reports/.gitignore
@@ -1,0 +1,2 @@
+/eda-demo_files/
+/eda-demo.html

--- a/reports/eda-demo.Rmd
+++ b/reports/eda-demo.Rmd
@@ -163,14 +163,14 @@ projetos %>%
 
 ```{r}
 projetos %>% 
-    ggplot(aes(x = sloc, color = lang)) + 
+    ggplot(aes(x = sloc_end, color = lang)) + 
     stat_ecdf() + 
     scale_x_log10()
 ```
 
 ```{r}
 projetos %>% 
-    ggplot(aes(x = build_success)) + 
+    ggplot(aes(x = build_success_prop)) + 
     geom_density()
 ```
 


### PR DESCRIPTION
Na hora de compilar, estava dando erro nas colunas 'sloc' e 'build_success', onde foram feitas as substituições por 'sloc_end' e 'build_success_prop'.
Também foi criado .gitignore para ignorar os arquivos criados após compilar.